### PR TITLE
Update documentation "3.2.8" -> "3.2.9"

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,11 @@
-# Nicotine-plus + noVNC Docker Container
+# Nicotine+ noVNC Docker Container
 
 ![Docker Pulls](https://shields.api-test.nl/docker/pulls/cproensa/nicotine-docker)
 ![Docker Image Size](https://shields.api-test.nl/docker/image-size/cproensa/nicotine-docker)
 
-This build is based on [realies/soulseek-docker](https://github.com/realies/soulseek-docker), adapted to run Nicotine-plus.
+This build is based on [realies/soulseek-docker](https://github.com/realies/soulseek-docker), adapted to run [nicotine-plus](https://github.com/nicotine-plus/nicotine-plus).
 
-His documentation has more details and most of those are also applicable here.
+The source documentation has more details and most of those are also applicable here.
 
 ## Setup
 
@@ -75,7 +75,7 @@ services:
 ### How To Build
 
 The Dockerfile script will copy an external .deb package during the build process, named `debian-package.zip`, which is the release package as described in the 
-![Nicotine-plus documentation](https://github.com/nicotine-plus/nicotine-plus/blob/master/doc/DOWNLOADS.md#ubuntudebian)
+![Nicotine+ documentation](https://github.com/nicotine-plus/nicotine-plus/blob/master/doc/DOWNLOADS.md#ubuntudebian)
 
 Straightforward build:
 

--- a/README.md
+++ b/README.md
@@ -91,12 +91,12 @@ Straightforward build:
 
   - *latest* to download the latest stable .deb release version
   - *testing* to donwload the latest nightly build .deb package
-  - *a specific version number* to download any version release .deb package (e.g. 3.2.8)
+  - *a specific version number* to download any version release .deb package (e.g. 3.2.9)
 
 [optional] *push user* is the user name to push image to the hub.
 
   - Example: build locally with development release: `./build testing`
      - This will create a tagged image: `nicotine-docker:testing` 
-  - Example: build with a version and push to hub: `./build 3.2.8 user_name`
-     - This will create a tagged image: `user_name/nicotine-docker:3.2.8` and push.
+  - Example: build with a version and push to hub: `./build 3.2.9 user_name`
+     - This will create a tagged image: `user_name/nicotine-docker:3.2.9` and push.
 

--- a/build.sh
+++ b/build.sh
@@ -2,7 +2,7 @@
 
 usage() {
     echo "Usage: $0 <target> [push-user]"
-    echo "<target> can be 'latest', 'testing', or a specific target version, e.g. '3.2.8'"
+    echo "<target> can be 'latest', 'testing', or a specific target version, e.g. '3.2.9'"
     echo "[push-user] optionally, the user for the hub and try to perform a push"
     exit 1
 }


### PR DESCRIPTION
+ Changed: "3.2.8" to "3.2.9" in the examples, because the older version had bugs in it.
- Removed: Original author pronoun, because this information is not known.
+ Added: Link to target project official "nicotine-plus" repo and use proper "Nicotine+" project title.